### PR TITLE
use page or section title and description

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{% if page.title %}{{ page.title }}{% endif %}</title>
+  <title>{{ page.title or section.title | safe }}</title>
   <meta name="author" content="{{ config.author }}" />
   <link rel="stylesheet" href="{{get_url(path='css/base.css') | safe }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
@@ -25,7 +25,7 @@
   </script>
 
   {% block meta %}
-  <meta name="description" content="{% if page.description %}{{ page.description }}{% endif %}" />
+  <meta name="description" content="{{ page.title or section.title | safe }}" />
   {% endblock %}
 </head>
 


### PR DESCRIPTION
Update base template to use section title as fallback for page title and improve meta description handling