### PR TITLE
Add meta description block for improved SEO

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="author" content="{{ config.author }}" />
+  {% block meta_description %}
+  <meta name="description" content="{{ config.description }}" />
+  {% endblock %}
+
   {% block og %}{% include "partials/base-og.html" %}{% endblock %}
 
   <!-- Links to files -->

--- a/templates/partials/blog-page-og.html
+++ b/templates/partials/blog-page-og.html
@@ -13,12 +13,14 @@
 <meta property="og:title"
     content="{% if page.title %}{{ page.title }}{% elif section.title %}{{ section.title }}{% else %}{{ config.title }}{% endif %}" />
 
+{% block meta_description %}
 {# Description and og:description: prefer page over section #}
 {% set meta_description = page.description | default(value=section.description) | default(value=config.description) %}
 {% if meta_description %}
 <meta name="description" content="{{ meta_description }}" />
 <meta property="og:description" content="{{ meta_description }}" />
 {% endif %}
+{% endblock %}
 
 {# Canonical URL and og:url #}
 {% set canonical_url = page.permalink | default(value=current_url) | default(value=config.base_url) %}


### PR DESCRIPTION
Introduce a meta description block in the base and blog page templates to enhance SEO by providing relevant page descriptions.