### PR TITLE
Update TanStack Router guide with Arktype and links

### DIFF
--- a/content/tanstack-router-opinionated-conventions-production-react-apps.md
+++ b/content/tanstack-router-opinionated-conventions-production-react-apps.md
@@ -3,12 +3,15 @@ title: "TanStack Router: Opinionated Guidelines for Production React Apps"
 date: 2025-08-15
 updated: 2025-08-30
 lang: en
-keywords: TanStack Router, React, TypeScript, Vite, Vitest, Routing, Guidelines
+keywords: TanStack Router, React, TypeScript, Vite, Vitest, Routing, Guidelines, Arktype
 description: "A practical guide to building production-ready React applications with TanStack Router, featuring opinionated guidelines for type-safe routing, data fetching, and state management. Learn how to leverage search params for shareable URLs, implement efficient loaders and mutations, and structure your codebase for maintainability. Based on real-world experience from MongoDB's Sales Apps Team."
 toc: true
 ---
 
 This post captures a practical way to implement a React application using TanStack Router. It focuses on maintainability, predictable data flows, and ergonomics for both reading and writing code.
+
+- [🔗 GitHub Repository](https://github.com/carlosvin/tanstack-router-prod-app)  
+- [🚀 Live Preview](https://carlosvin.github.io/tanstack-router-prod-app/)
 
 > **Note:**  
 > The guidelines and recommendations in this guide are based on our real-world experience building a new internal application as the Sales Apps Team at [MongoDB](https://www.mongodb.com). They reflect lessons learned and best practices developed throughout that process.


### PR DESCRIPTION
Enhance the TanStack Router guide by adding Arktype to the keywords and including links to the GitHub repository and live preview.