### PR TITLE
Refactor HTML meta tags for consistency

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -14,13 +14,13 @@
   {% else %}
   {% set description = config.description %}
   {% endif %}
-  <meta name="description" content="{{ description }}" />
+  <meta name="description" content="{{ description }}">
 
 
   <!-- Meta tags and OpenGraph metadata for SEO, social sharing, and browser configuration -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="author" content="{{ config.author }}" />
+  <meta name="author" content="{{ config.author }}">
   {% block rss %}
   <link rel="alternate" type="application/rss+xml" title="RSS"
     href="{{ get_url(path='rss.xml', trailing_slash=false) }}">
@@ -34,14 +34,12 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.lime.min.css" rel=preconnect>
 
   <!-- Favicons -->
-  <link rel="icon" href="{{get_url(path='img/favicon.ico') | safe }}" sizes="any" />
-  <link rel="icon" href="{{get_url(path='img/favicon-32x32.png') | safe }}" sizes="32x32" type="image/png" />
-  <link rel="icon" href="{{get_url(path='img/android-chrome-192x192.png') | safe }}" sizes="192x192" type="image/png" />
-  <link rel="apple-touch-icon" href="{{get_url(path='img/apple-touch-icon.png') | safe }}" />
+  <link rel="icon" href="{{get_url(path='img/favicon.ico') | safe }}" sizes="any">
+  <link rel="icon" href="{{get_url(path='img/favicon-32x32.png') | safe }}" sizes="32x32" type="image/png">
+  <link rel="icon" href="{{get_url(path='img/android-chrome-192x192.png') | safe }}" sizes="192x192" type="image/png">
+  <link rel="apple-touch-icon" href="{{get_url(path='img/apple-touch-icon.png') | safe }}">
 
-  <link rel="manifest" href="{{ get_url(path='manifest.json') | safe }}" />
-
-  <!-- Scripts -->
+  <link rel="manifest" href="{{ get_url(path='manifest.json') | safe }}"> <!-- Scripts -->
   <script type="speculationrules">
     {
     "prerender": [

--- a/templates/blog-page.html
+++ b/templates/blog-page.html
@@ -6,7 +6,7 @@
   <header>
     <hgroup>
       <h1 class="post-title">{{ page.title }}</h1>
-      <div class="post-meta">
+      <p class="post-meta">
         {% if page.updated %}
         <time datetime="{{ page.updated | date(format=" %Y-%m-%d") }}">
           {{ page.updated | date(format="%B %d, %Y") }}
@@ -16,7 +16,7 @@
           {{ page.date | date(format="%B %d, %Y") }}
         </time>
         {% endif %}
-      </div>
+      </p>
     </hgroup>
   </header>
 

--- a/templates/partials/base-og.html
+++ b/templates/partials/base-og.html
@@ -1,4 +1,4 @@
-<meta property="og:type" content="website" />
-<meta property="og:site_name" content="{{ config.title }}" />
-<meta property="og:url" content="{{ current_url | default(value=config.base_url) }}" />
-<meta property="og:locale" content="{{ config.extra.og_locale | default(value='en_US') }}" />
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="{{ config.title }}">
+<meta property="og:url" content="{{ current_url | default(value=config.base_url) }}">
+<meta property="og:locale" content="{{ config.extra.og_locale | default(value='en_US') }}">

--- a/templates/partials/blog-page-og.html
+++ b/templates/partials/blog-page-og.html
@@ -3,45 +3,45 @@
 {# Set title variable: prefer page over section over config #}
 
 {# Title and og:title #}
-<meta property="og:title" content="{{ title }}" />
-<meta property="og:description" content="{{ description }}" />
+<meta property="og:title" content="{{ title }}">
+<meta property="og:description" content="{{ description }}">
 
 
 {# Canonical URL and og:url #}
 {% set canonical_url = page.permalink | default(value=current_url) | default(value=config.base_url) %}
-<link rel="canonical" href="{{ canonical_url }}" />
-<meta property="og:url" content="{{ canonical_url }}" />
+<link rel="canonical" href="{{ canonical_url }}">
+<meta property="og:url" content="{{ canonical_url }}">
 
 {# og:type: article for blog posts #}
-<meta property="og:type" content="article" />
+<meta property="og:type" content="article">
 
 {# og:site_name #}
-<meta property="og:site_name" content="{{ config.title }}" />
+<meta property="og:site_name" content="{{ config.title }}">
 
 {# og:locale #}
-<meta property="og:locale" content="{{ config.extra.og_locale | default(value='en_US') }}" />
+<meta property="og:locale" content="{{ config.extra.og_locale | default(value='en_US') }}">
 
 {# Article published/modified time #}
 {% if page.date %}
-<meta property="article:published_time" content="{{ page.date | date(format='%Y-%m-%dT%H:%M:%SZ') }}" />
+<meta property="article:published_time" content="{{ page.date | date(format='%Y-%m-%dT%H:%M:%SZ') }}">
 {% endif %}
 {% if page.updated %}
-<meta property="article:modified_time" content="{{ page.updated | date(format='%Y-%m-%dT%H:%M:%SZ') }}" />
+<meta property="article:modified_time" content="{{ page.updated | date(format='%Y-%m-%dT%H:%M:%SZ') }}">
 {% endif %}
 
 {# og:image: use page.preview_image or fallback #}
 {% set og_image = page.preview_image | default(value=config.extra.preview_image) %}
 {% if og_image %}
-<meta property="og:image" content="{{ og_image }}" />
+<meta property="og:image" content="{{ og_image }}">
 {% endif %}
 
 {# Twitter Card #}
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:title" content="{{ title }}" />
-<meta name="twitter:description" content="{{ description }}" />
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ title }}">
+<meta name="twitter:description" content="{{ description }}">
 {% if og_image %}
-<meta name="twitter:image" content="{{ og_image }}" />
+<meta name="twitter:image" content="{{ og_image }}">
 {% endif %}
 {% if config.extra.twitter_site %}
-<meta name="twitter:site" content="{{ config.extra.twitter_site }}" />
+<meta name="twitter:site" content="{{ config.extra.twitter_site }}">
 {% endif %}

--- a/templates/partials/social.html
+++ b/templates/partials/social.html
@@ -8,6 +8,6 @@
       width="32" height="32" />
   </a>
   <a href="{{ get_url(path='atom.xml') }}">
-    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/rss.svg" alt="RSS" width="32" height="32" />
+    <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/rss.svg" alt="RSS" width="32" height="32">
   </a>
 </span>


### PR DESCRIPTION
Remove self-closing syntax from HTML meta tags to ensure uniformity across the codebase.